### PR TITLE
adding continueAfterCopyWithOwner flag

### DIFF
--- a/go/vt/vtctl/vtctl.go
+++ b/go/vt/vtctl/vtctl.go
@@ -2280,6 +2280,7 @@ func commandCreateLookupVindex(ctx context.Context, wr *wrangler.Wrangler, subFl
 	//TODO: keep -cell around for backward compatibility and remove it in a future version
 	cell := subFlags.String("cell", "", "Cell to replicate from.")
 	tabletTypes := subFlags.String("tablet_types", "", "Source tablet types to replicate from.")
+	continueAfterCopyWithOwner := subFlags.Bool("continue_after_copy_with_owner", false, "Vindex will continue materialization after copy when an owner is provided")
 	if err := subFlags.Parse(args); err != nil {
 		return err
 	}
@@ -2294,7 +2295,7 @@ func commandCreateLookupVindex(ctx context.Context, wr *wrangler.Wrangler, subFl
 	if err := json2.Unmarshal([]byte(subFlags.Arg(1)), specs); err != nil {
 		return err
 	}
-	return wr.CreateLookupVindex(ctx, keyspace, specs, *cell, *tabletTypes)
+	return wr.CreateLookupVindex(ctx, keyspace, specs, *cell, *tabletTypes, *continueAfterCopyWithOwner)
 }
 
 func commandExternalizeVindex(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {

--- a/go/vt/wrangler/keyspace.go
+++ b/go/vt/wrangler/keyspace.go
@@ -1258,12 +1258,12 @@ func (wr *Wrangler) replicaMigrateServedFrom(ctx context.Context, ki *topo.Keysp
 // a bit different than for rdonly / replica to guarantee a smooth transition.
 //
 // The order is as follows:
-// - Add BlacklistedTables on the source shard map for master
-// - Refresh the source master, so it stops writing on the tables
-// - Get the source master position, wait until destination master reaches it
-// - Clear SourceShard on the destination Shard
-// - Refresh the destination master, so its stops its filtered
-//   replication and starts accepting writes
+//   - Add BlacklistedTables on the source shard map for master
+//   - Refresh the source master, so it stops writing on the tables
+//   - Get the source master position, wait until destination master reaches it
+//   - Clear SourceShard on the destination Shard
+//   - Refresh the destination master, so its stops its filtered
+//     replication and starts accepting writes
 func (wr *Wrangler) masterMigrateServedFrom(ctx context.Context, ki *topo.KeyspaceInfo, sourceShard *topo.ShardInfo, destinationShard *topo.ShardInfo, tables []string, ev *events.MigrateServedFrom, filteredReplicationWaitTime time.Duration) error {
 	// Read the data we need
 	ctx, cancel := context.WithTimeout(ctx, filteredReplicationWaitTime)

--- a/go/vt/wrangler/materializer.go
+++ b/go/vt/wrangler/materializer.go
@@ -343,8 +343,8 @@ func (wr *Wrangler) checkIfPreviousJournalExists(ctx context.Context, mz *materi
 }
 
 // CreateLookupVindex creates a lookup vindex and sets up the backfill.
-func (wr *Wrangler) CreateLookupVindex(ctx context.Context, keyspace string, specs *vschemapb.Keyspace, cell, tabletTypes string) error {
-	ms, sourceVSchema, targetVSchema, err := wr.prepareCreateLookup(ctx, keyspace, specs)
+func (wr *Wrangler) CreateLookupVindex(ctx context.Context, keyspace string, specs *vschemapb.Keyspace, cell, tabletTypes string, continueAfterCopyWithOwner bool) error {
+	ms, sourceVSchema, targetVSchema, err := wr.prepareCreateLookup(ctx, keyspace, specs, continueAfterCopyWithOwner)
 	if err != nil {
 		return err
 	}
@@ -364,7 +364,7 @@ func (wr *Wrangler) CreateLookupVindex(ctx context.Context, keyspace string, spe
 }
 
 // prepareCreateLookup performs the preparatory steps for creating a lookup vindex.
-func (wr *Wrangler) prepareCreateLookup(ctx context.Context, keyspace string, specs *vschemapb.Keyspace) (ms *vtctldatapb.MaterializeSettings, sourceVSchema, targetVSchema *vschemapb.Keyspace, err error) {
+func (wr *Wrangler) prepareCreateLookup(ctx context.Context, keyspace string, specs *vschemapb.Keyspace, continueAfterCopyWithOwner bool) (ms *vtctldatapb.MaterializeSettings, sourceVSchema, targetVSchema *vschemapb.Keyspace, err error) {
 	// Important variables are pulled out here.
 	var (
 		// lookup vindex info
@@ -617,7 +617,7 @@ func (wr *Wrangler) prepareCreateLookup(ctx context.Context, keyspace string, sp
 		Workflow:       targetTableName + "_vdx",
 		SourceKeyspace: keyspace,
 		TargetKeyspace: targetKeyspace,
-		StopAfterCopy:  vindex.Owner != "",
+		StopAfterCopy:  vindex.Owner != "" && !continueAfterCopyWithOwner,
 		TableSettings: []*vtctldatapb.TableMaterializeSettings{{
 			TargetTable:      targetTableName,
 			SourceExpression: materializeQuery,

--- a/go/vt/wrangler/materializer_test.go
+++ b/go/vt/wrangler/materializer_test.go
@@ -1560,11 +1560,13 @@ func TestExternalizeVindex(t *testing.T) {
 		},
 	}
 	fields := sqltypes.MakeTestFields(
-		"id|state|message",
-		"int64|varbinary|varbinary",
+		"id|state|message|source",
+		"int64|varbinary|varbinary|blob",
 	)
-	running := sqltypes.MakeTestResult(fields, "1|Running|msg")
-	stopped := sqltypes.MakeTestResult(fields, "1|Stopped|Stopped after copy")
+	sourceStopAfterCopy := `keyspace:"sourceKs",shard:"0",filter:{rules:{match:"owned" filter:"select * from t1 where in_keyrange(col1, 'sourceKs.hash', '-80')"}} stop_after_copy:true`
+	sourceKeepRunningAfterCopy := `keyspace:"sourceKs",shard:"0",filter:{rules:{match:"owned" filter:"select * from t1 where in_keyrange(col1, 'sourceKs.hash', '-80')"}}`
+	running := sqltypes.MakeTestResult(fields, "1|Running|msg|"+sourceKeepRunningAfterCopy)
+	stopped := sqltypes.MakeTestResult(fields, "1|Stopped|Stopped after copy|"+sourceStopAfterCopy)
 	testcases := []struct {
 		input        string
 		vrResponse   *sqltypes.Result
@@ -1587,9 +1589,9 @@ func TestExternalizeVindex(t *testing.T) {
 		input: "sourceks.bad",
 		err:   "table name in vindex should be of the form keyspace.table: unqualified",
 	}, {
-		input:      "sourceks.owned",
-		vrResponse: running,
-		err:        "is not in Stopped after copy state",
+		input:        "sourceks.owned",
+		vrResponse:   running,
+		expectDelete: true,
 	}, {
 		input:      "sourceks.unowned",
 		vrResponse: stopped,
@@ -1601,7 +1603,7 @@ func TestExternalizeVindex(t *testing.T) {
 			t.Fatal(err)
 		}
 		if tcase.vrResponse != nil {
-			validationQuery := "select id, state, message from _vt.vreplication where workflow='lkp_vdx' and db_name='vt_targetks'"
+			validationQuery := "select id, state, message, source from _vt.vreplication where workflow='lkp_vdx' and db_name='vt_targetks'"
 			env.tmc.expectVRQuery(200, validationQuery, tcase.vrResponse)
 			env.tmc.expectVRQuery(210, validationQuery, tcase.vrResponse)
 		}

--- a/go/vt/wrangler/vdiff.go
+++ b/go/vt/wrangler/vdiff.go
@@ -264,7 +264,7 @@ func (wr *Wrangler) VDiff(ctx context.Context, targetKeyspace, workflowName, sou
 		if err != nil {
 			wr.Logger().Printf("Error converting report to json: %v", err.Error())
 		}
-		jsonOutput += fmt.Sprintf("%s", json)
+		jsonOutput += string(json)
 		wr.logger.Printf("%s", jsonOutput)
 	} else {
 		for table, dr := range diffReports {


### PR DESCRIPTION
Backporting https://github.com/vitessio/vitess/pull/9771

> ## Description
> We did not check for [the saved StopAfterCopy config value](https://github.com/vitessio/vitess/blob/2c0a29df5d513167ac0f600d8916128b15d1063e/go/vt/wrangler/materializer.go#L679) (➡️ [here for the `INSERT` to generate the `_vt.vreplication` row](https://github.com/vitessio/vitess/blob/2c0a29df5d513167ac0f600d8916128b15d1063e/go/vt/wrangler/materializer.go#L1087)) in the workflow [when attempting to externalize it](https://github.com/vitessio/vitess/blob/2c0a29df5d513167ac0f600d8916128b15d1063e/go/vt/wrangler/materializer.go#L758-L782). When the [`-continue_after_copy_with_owner=true`](https://vitess.io/docs/13.0/user-guides/configuration-advanced/createlookupvindex/) flag ([added in v12.0](https://github.com/vitessio/vitess/pull/8572/commits/7e7722ac7b51aa62c42b81a7e679e8acb1c15384)) was used for the [`CreateLookupVindex`](https://vitess.io/docs/13.0/user-guides/configuration-advanced/createlookupvindex/) command — which means that the `_vt.vreplication.source` value does __not__ have `stop_after_copy:true` in it — the workflow state will be `Running` when it's healthy and we should be checking for that.
> 
> Instead, before this PR we would fail to externalize the VIndex when `-continue_after_copy_with_owner=true` was used and the workflow was running (as is expected and proper in that case) with an error here:
> 
> https://github.com/vitessio/vitess/blob/2c0a29df5d513167ac0f600d8916128b15d1063e/go/vt/wrangler/materializer.go#L776-L779
> 
> ## Related Issue(s)
> * Follow-up to: [Customized CreateLookUpVindex to Include a Flag to Continue Vreplication After Backfill with an Owner Provided #8572](https://github.com/vitessio/vitess/pull/8572)
> 
> ## Checklist
> * [x]  Should this PR be backported? YES, at least to release-13.0
> * [x]  Tests were updated
> * [x]  Documentation is not required

